### PR TITLE
Remove function call that seems to be generating unwanted output.

### DIFF
--- a/src/Shortcodes.php
+++ b/src/Shortcodes.php
@@ -1544,8 +1544,6 @@ class Shortcodes {
       $dialog_class[] = 'modal-dialog';
       $dialog_class[]	= (Utilities::is_flag('centered', $save_atts)) ? 'modal-dialog-centered' : '';
 
-			$content = do_shortcode( $content );
-
 			$return = Utilities::bs_output(
 				sprintf(
           '<div id="%s" class="%s" tabindex="-1" role="dialog" %s>


### PR DESCRIPTION
I'm not completely sure because I was actually experimenting with just using this single shortcode (supported by the utilities) in another plugin, but it looks like the line I removed was making the shortcode run twice, as well as generating output in the admin, before headers.

If not, sorry for the noise, man. 